### PR TITLE
fix: no text in age verification popup "Yes" button

### DIFF
--- a/public/templates/wplegalpages-age-button.php
+++ b/public/templates/wplegalpages-age-button.php
@@ -11,7 +11,7 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
-$lp_eu_button_text    = get_option( 'lp_eu_button_text' );
+$lp_eu_button_text    = get_option( 'lp_eu_button_text' , 'Yes, I am');
 $lp_eu_button_text_no = get_option( 'lp_eu_button_text_no' , 'No, I am not');
 $data                 = apply_filters( 'wplegalpages_pro_invalid_description', get_option( '_lp_invalid_description', __( 'We are Sorry.', 'wplegalpages' ) ) );
 ?>


### PR DESCRIPTION
### All Submissions:

* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [ ] My pull request has a descriptive title (not a vague title like `Update index.md`)
* [ ] I have tested these changes either locally on my machine, or GitPod.

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
